### PR TITLE
Change how assignment fields are stored.

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddAssignmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAssignmentCommand.java
@@ -34,14 +34,12 @@ public class AddAssignmentCommand extends Command {
             + PREFIX_DEADLINE + "DEADLINE "
             + PREFIX_STUDENT_NUMBER + "STUDENT NUMBER (OPTIONAL) "
             + PREFIX_STATUS + "SUBMISSION STATUS (OPTIONAL) "
-            + PREFIX_STATUS + "GRADING STATUS (OPTIONAL) "
             + PREFIX_GRADE + "GRADE (OPTIONAL) "
             + "\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "Jane Doe "
             + PREFIX_ASSIGNMENT + "Math Quiz "
             + PREFIX_DEADLINE + "2024-10-09 "
-            + PREFIX_STATUS + "N "
             + PREFIX_STATUS + "N "
             + PREFIX_GRADE + "NULL ";
 

--- a/src/main/java/seedu/address/logic/parser/AddAssignmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAssignmentCommandParser.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT_NUMBER;
 
-import java.util.List;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddAssignmentCommand;
@@ -26,7 +25,7 @@ import seedu.address.model.student.StudentNumber;
  */
 public class AddAssignmentCommandParser implements Parser<AddAssignmentCommand> {
 
-    public static final String MESSAGE_EXPECTED_GRADE = "Expected a grade if grading has already been done\n"
+    public static final String MESSAGE_UNEXPECTED_GRADE = "Should not be graded if assignment has not been submitted.\n"
             + AddAssignmentCommand.MESSAGE_USAGE;
 
 
@@ -48,30 +47,31 @@ public class AddAssignmentCommandParser implements Parser<AddAssignmentCommand> 
         AssignmentName assignmentName = ParserUtil.parseAssignmentName(
                 argMultimap.getValue(PREFIX_ASSIGNMENT).get());
 
-        // Initializing non-compulsory fields
-        List<Status> statusList = ParserUtil.parseStatuses(argMultimap.getAllValues(PREFIX_STATUS), 2);
-        Status submissionStatus = statusList.get(0);
-        Status gradingStatus = statusList.get(1);
+        Status status = Status.getDefault();
+        if (argMultimap.getValue(PREFIX_STATUS).isPresent()) {
+            status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get());
+        }
 
-        Grade grade;
-        if (gradingStatus.isGraded()) {
-            grade = ParserUtil.parseGrade(argMultimap.getValue(PREFIX_GRADE)
-                    .orElseThrow(() -> new ParseException(MESSAGE_EXPECTED_GRADE)
-            ));
-        } else {
-            grade = Grade.getDefault();
+        Grade grade = Grade.getDefault();
+        if (argMultimap.getValue(PREFIX_GRADE).isPresent()) {
+            grade = ParserUtil.parseGrade(argMultimap.getValue(PREFIX_GRADE).get());
+        }
+
+        // Cannot be graded while not submitted
+        if (!status.isSubmitted() && grade.isGraded()) {
+            throw new ParseException((MESSAGE_UNEXPECTED_GRADE));
         }
 
         if (argMultimap.getValue(PREFIX_STUDENT_NUMBER).isPresent()) {
             StudentNumber studentNumber =
                     ParserUtil.parseStudentNumber(argMultimap.getValue(PREFIX_STUDENT_NUMBER).get());
             return new AddAssignmentCommand(name,
-                    new Assignment(assignmentName, deadline, submissionStatus, gradingStatus, grade),
+                    new Assignment(assignmentName, deadline, status, grade),
                     studentNumber);
         }
 
         return new AddAssignmentCommand(name,
-                new Assignment(assignmentName, deadline, submissionStatus, gradingStatus, grade));
+                new Assignment(assignmentName, deadline, status, grade));
     }
 
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {

--- a/src/main/java/seedu/address/logic/parser/EditAssignmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditAssignmentCommandParser.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT_NUMBER;
 
 import java.util.stream.Stream;
 
+import seedu.address.logic.commands.AddAssignmentCommand;
 import seedu.address.logic.commands.EditAssignmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.assignment.AssignmentName;
@@ -24,6 +25,10 @@ import seedu.address.model.student.StudentNumber;
  * Parses input arguments and creates a new EditAssignmentCommand object
  */
 public class EditAssignmentCommandParser implements Parser<EditAssignmentCommand> {
+
+    public static final String MESSAGE_UNEXPECTED_GRADE = "Should not be graded if assignment has not been submitted.\n"
+            + AddAssignmentCommand.MESSAGE_USAGE;
+
     @Override
     public EditAssignmentCommand parse(String userInput) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(userInput,
@@ -42,7 +47,6 @@ public class EditAssignmentCommandParser implements Parser<EditAssignmentCommand
         // Initializing non-compulsory fields
         Deadline queryDeadline;
         Status querySubmissionStatus;
-        Status queryGradingStatus;
         Grade queryGrade;
 
         if (argMultimap.getValue(PREFIX_DEADLINE).isPresent()) {
@@ -51,16 +55,10 @@ public class EditAssignmentCommandParser implements Parser<EditAssignmentCommand
             queryDeadline = null;
         }
 
-        if (argMultimap.getAllValues(PREFIX_STATUS).size() > 0) {
+        if (argMultimap.getValue(PREFIX_STATUS).isPresent()) {
             querySubmissionStatus = ParserUtil.parseStatus(argMultimap.getAllValues(PREFIX_STATUS).get(0));
         } else {
             querySubmissionStatus = null;
-        }
-
-        if (argMultimap.getAllValues(PREFIX_STATUS).size() > 1) {
-            queryGradingStatus = ParserUtil.parseStatus(argMultimap.getAllValues(PREFIX_STATUS).get(1));
-        } else {
-            queryGradingStatus = null;
         }
 
         if (argMultimap.getValue(PREFIX_GRADE).isPresent()) {
@@ -73,13 +71,13 @@ public class EditAssignmentCommandParser implements Parser<EditAssignmentCommand
             StudentNumber studentNumber =
                     ParserUtil.parseStudentNumber(argMultimap.getValue(PREFIX_STUDENT_NUMBER).get());
             return new EditAssignmentCommand(name, assignmentName,
-                    new AssignmentQuery(null, queryDeadline, querySubmissionStatus, queryGradingStatus, queryGrade),
+                    new AssignmentQuery(null, queryDeadline, querySubmissionStatus, queryGrade),
                     studentNumber);
         }
 
         return new EditAssignmentCommand(name, assignmentName,
                 new AssignmentQuery(null, queryDeadline,
-                        querySubmissionStatus, queryGradingStatus, queryGrade));
+                        querySubmissionStatus, queryGrade));
     }
 
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {

--- a/src/main/java/seedu/address/model/assignment/Assignment.java
+++ b/src/main/java/seedu/address/model/assignment/Assignment.java
@@ -13,7 +13,6 @@ public class Assignment {
     private AssignmentName assignmentName;
     private Deadline deadline;
     private Status submissionStatus;
-    private Status gradingStatus;
     private Grade grade;
 
     /**
@@ -22,16 +21,14 @@ public class Assignment {
      * @param assignmentName A valid name
      * @param deadline A valid date
      * @param submissionStatus A valid subsmission status
-     * @param gradingStatus A valid grading status
      * @param grade A valid grade
      */
     public Assignment(AssignmentName assignmentName, Deadline deadline, Status submissionStatus,
-                      Status gradingStatus, Grade grade) {
-        requireAllNonNull(assignmentName, deadline, submissionStatus, gradingStatus);
+                      Grade grade) {
+        requireAllNonNull(assignmentName, deadline, submissionStatus);
         this.assignmentName = assignmentName;
         this.deadline = deadline;
         this.submissionStatus = submissionStatus;
-        this.gradingStatus = gradingStatus;
         this.grade = grade;
     }
 
@@ -63,15 +60,6 @@ public class Assignment {
     }
 
     /**
-     * Returns the {@code Grading Status} of the assignment.
-     *
-     * @return The grading status of the assignment.
-     */
-    public Status getGradingStatus() {
-        return gradingStatus;
-    }
-
-    /**
      * Returns the {@code Grade} of the assignment.
      *
      * @return The grade of the assignment.
@@ -84,6 +72,10 @@ public class Assignment {
         return assignmentName.equals(other.assignmentName);
     }
 
+    public boolean isValid() {
+        return submissionStatus.isSubmitted() || !grade.isGraded();
+    }
+
     /**
      * Edits relevant fields
      *
@@ -92,7 +84,6 @@ public class Assignment {
     public void edit(AssignmentQuery assignmentQuery) {
         this.deadline = assignmentQuery.queryDeadline.orElse(this.deadline);
         this.submissionStatus = assignmentQuery.querySubmissionStatus.orElse(this.submissionStatus);
-        this.gradingStatus = assignmentQuery.queryGradingStatus.orElse(this.gradingStatus);
         this.grade = assignmentQuery.queryGrade.orElse(this.grade);
     }
 
@@ -102,7 +93,6 @@ public class Assignment {
                 .add("name", assignmentName)
                 .add("deadline", deadline)
                 .add("submission status", submissionStatus)
-                .add("grading status", gradingStatus)
                 .add("grade", grade)
                 .toString();
     }
@@ -121,7 +111,6 @@ public class Assignment {
         return this.assignmentName.equals(otherAssignment.assignmentName)
                 && this.deadline.equals(otherAssignment.deadline)
                 && this.submissionStatus.equals(otherAssignment.submissionStatus)
-                && this.gradingStatus.equals(otherAssignment.gradingStatus)
                 && this.grade.equals(otherAssignment.grade);
     }
 }

--- a/src/main/java/seedu/address/model/assignment/AssignmentQuery.java
+++ b/src/main/java/seedu/address/model/assignment/AssignmentQuery.java
@@ -10,18 +10,16 @@ public class AssignmentQuery {
     public final Optional<AssignmentName> queryName;
     public final Optional<Deadline> queryDeadline;
     public final Optional<Status> querySubmissionStatus;
-    public final Optional<Status> queryGradingStatus;
     public final Optional<Grade> queryGrade;
 
     /**
      * Constructs an {@code AssignmentQuery}
      */
     public AssignmentQuery(AssignmentName assignmentName, Deadline deadline, Status submissionStatus,
-                           Status gradingStatus, Grade grade) {
+                        Grade grade) {
         this.queryName = Optional.ofNullable(assignmentName);
         this.queryDeadline = Optional.ofNullable(deadline);
         this.querySubmissionStatus = Optional.ofNullable(submissionStatus);
-        this.queryGradingStatus = Optional.ofNullable(gradingStatus);
         this.queryGrade = Optional.ofNullable(grade);
     }
 
@@ -32,7 +30,6 @@ public class AssignmentQuery {
         this.queryName = Optional.ofNullable(assignment.getAssignmentName());
         this.queryDeadline = Optional.ofNullable(assignment.getDeadline());
         this.querySubmissionStatus = Optional.ofNullable(assignment.getSubmissionStatus());
-        this.queryGradingStatus = Optional.ofNullable(assignment.getGradingStatus());
         this.queryGrade = Optional.ofNullable(assignment.getGrade());
     }
 
@@ -58,7 +55,6 @@ public class AssignmentQuery {
         return matchQuery(queryName, assignment.getAssignmentName())
                 && matchQuery(queryDeadline, assignment.getDeadline())
                 && matchQuery(querySubmissionStatus, assignment.getSubmissionStatus())
-                && matchQuery(queryGradingStatus, assignment.getGradingStatus())
                 && matchQuery(queryGrade, assignment.getGrade());
     }
 
@@ -76,7 +72,6 @@ public class AssignmentQuery {
         return otherQuery.queryName.equals(this.queryName)
                 && otherQuery.queryDeadline.equals(this.queryDeadline)
                 && otherQuery.querySubmissionStatus.equals(this.querySubmissionStatus)
-                && otherQuery.queryGradingStatus.equals(this.queryGradingStatus)
                 && otherQuery.queryGrade.equals(this.queryGrade);
     }
 

--- a/src/main/java/seedu/address/model/assignment/Grade.java
+++ b/src/main/java/seedu/address/model/assignment/Grade.java
@@ -56,6 +56,15 @@ public class Grade {
         return new Grade();
     }
 
+    /**
+     * Returns if grade is non-null
+     *
+     * @return
+     */
+    public boolean isGraded() {
+        return grade.isPresent();
+    }
+
     @Override
     public String toString() {
         return grade.map(g -> new DecimalFormat("#.00").format(grade.get())).orElse("NULL");

--- a/src/main/java/seedu/address/model/assignment/Status.java
+++ b/src/main/java/seedu/address/model/assignment/Status.java
@@ -62,9 +62,9 @@ public class Status {
     }
 
     /**
-     * Returns true if the assignment is graded
+     * Returns true if the assignment is submitted
      */
-    public boolean isGraded() {
+    public boolean isSubmitted() {
         return status == State.Y;
     }
 

--- a/src/main/java/seedu/address/model/assignment/exceptions/InvalidAssignmentException.java
+++ b/src/main/java/seedu/address/model/assignment/exceptions/InvalidAssignmentException.java
@@ -1,0 +1,10 @@
+package seedu.address.model.assignment.exceptions;
+
+/**
+ * Signals that the operation will result in an invalid assigment.
+ */
+public class InvalidAssignmentException extends Exception {
+    public InvalidAssignmentException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/seedu/address/model/student/Student.java
+++ b/src/main/java/seedu/address/model/student/Student.java
@@ -195,6 +195,21 @@ public class Student {
     }
 
     /**
+     * Returns the assignment matching the name, null if no match found
+     *
+     * @param assignmentName A valid assignment name
+     * @return the matching assignment
+     */
+    public Assignment getAssignment(AssignmentName assignmentName) {
+        for (Assignment assignment : assignments) {
+            if (assignment.getAssignmentName().equals(assignmentName)) {
+                return assignment;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Edits the assignment matching the given name to the parameters specified
      *
      * @param assignmentQuery A valid assignment query.

--- a/src/main/java/seedu/address/storage/JsonAdaptedAssignment.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedAssignment.java
@@ -19,7 +19,6 @@ public class JsonAdaptedAssignment {
     private final String assignmentName;
     private final String deadline;
     private final String submissionStatus;
-    private final String gradingStatus;
     private final String grade;
 
     /**
@@ -29,12 +28,10 @@ public class JsonAdaptedAssignment {
     public JsonAdaptedAssignment(@JsonProperty("assignmentName") String assignmentName,
                                  @JsonProperty("deadline") String deadline,
                                  @JsonProperty("submissionStatus") String submissionStatus,
-                                 @JsonProperty("gradingStatus") String gradingStatus,
                                  @JsonProperty("grade") String grade) {
         this.assignmentName = assignmentName;
         this.deadline = deadline;
         this.submissionStatus = submissionStatus;
-        this.gradingStatus = gradingStatus;
         this.grade = grade;
     }
 
@@ -46,7 +43,6 @@ public class JsonAdaptedAssignment {
         assignmentName = source.getAssignmentName().fullName;
         deadline = source.getDeadline().deadline.toString();
         submissionStatus = source.getSubmissionStatus().status.toString();
-        gradingStatus = source.getGradingStatus().status.toString();
         grade = source.getGrade().grade
                 .map(x -> x.toString())
                 .orElse("NULL");
@@ -87,15 +83,6 @@ public class JsonAdaptedAssignment {
         }
         final Status modelSubmissionStatus = new Status(submissionStatus);
 
-        if (gradingStatus == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Status.class.getSimpleName()));
-        }
-
-        if (!Status.isValidStatus(gradingStatus)) {
-            throw new IllegalValueException(Status.MESSAGE_CONSTRAINTS);
-        }
-        final Status modelGradingStatus = new Status(gradingStatus);
-
         if (grade == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Grade.class.getSimpleName()));
         }
@@ -106,8 +93,7 @@ public class JsonAdaptedAssignment {
 
         final Grade modelGrade = new Grade(grade);
 
-        return new Assignment(modelAssignmentName, modelDeadline, modelSubmissionStatus, modelGradingStatus,
-                modelGrade);
+        return new Assignment(modelAssignmentName, modelDeadline, modelSubmissionStatus, modelGrade);
 
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddAssignmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddAssignmentCommandParserTest.java
@@ -5,6 +5,8 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_STUDENT_NUMBE
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_STUDENT_NUMBER_TOO_FEW_NUMBERS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENT_NUMBER_HUGH;
+import static seedu.address.logic.parser.AddAssignmentCommandParser.MESSAGE_UNEXPECTED_GRADE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GRADE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT_NUMBER;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -22,7 +24,7 @@ import seedu.address.model.student.StudentNumber;
 
 public class AddAssignmentCommandParserTest {
 
-    private static final String VALID_INPUT = " n/John Doe a/CS2103 Project d/2024-12-01 s/Y s/Y g/85.5";
+    private static final String VALID_INPUT = " n/John Doe a/CS2103 Project d/2024-12-01 s/Y g/85.5";
     private static final String MISSING_NAME_INPUT = " a/CS2103 Project d/2024-12-01";
     private static final String MISSING_ASSIGNMENT_NAME_INPUT = " n/John Doe d/2024-12-01";
     private static final String MISSING_DEADLINE_INPUT = " n/John Doe a/CS2103 Project";
@@ -40,7 +42,6 @@ public class AddAssignmentCommandParserTest {
                 new Assignment(
                         new AssignmentName("CS2103 Project"),
                         new Deadline("2024-12-01"),
-                        new Status("Y"),
                         new Status("Y"),
                         new Grade("85.5")
                 )
@@ -81,7 +82,6 @@ public class AddAssignmentCommandParserTest {
                         new AssignmentName("CS2103 Project"),
                         new Deadline("2024-12-01"),
                         new Status("Y"),
-                        Status.getDefault(), // Assuming the default grading status is "N"
                         Grade.getDefault() // Assuming the default grade is NULL or empty
                 )
         );
@@ -97,7 +97,6 @@ public class AddAssignmentCommandParserTest {
                         new AssignmentName("CS2103 Project"),
                         new Deadline("2024-12-01"),
                         Status.getDefault(), // Default submission status
-                        new Status("N"),
                         Grade.getDefault() // Assuming the default grade is NULL or empty
                 )
         );
@@ -113,7 +112,6 @@ public class AddAssignmentCommandParserTest {
                         new AssignmentName("CS2103 Project"),
                         new Deadline("2024-12-01"),
                         new Status("Y"),
-                        Status.getDefault(), // Default grading status
                         Grade.getDefault() // Assuming the default grade is NULL or empty
                 )
         );
@@ -135,6 +133,14 @@ public class AddAssignmentCommandParserTest {
     }
 
     @Test
+    public void parse_invalidAssignment_failure() {
+        assertParseFailure(parser,
+                GRADING_STATUS_NOT_GRADED_INPUT + " "
+                        + PREFIX_GRADE + "100",
+                MESSAGE_UNEXPECTED_GRADE);
+    }
+
+    @Test
     public void parse_validStudentNumber_success() {
         Name name = new Name(VALID_NAME_BOB);
         AddAssignmentCommand expectedCommand = new AddAssignmentCommand(
@@ -142,7 +148,6 @@ public class AddAssignmentCommandParserTest {
                 new Assignment(
                         new AssignmentName("CS2103 Project"),
                         new Deadline("2024-12-01"),
-                        new Status("Y"),
                         new Status("Y"),
                         new Grade("85.5")
                 ),

--- a/src/test/java/seedu/address/logic/parser/EditAssignmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditAssignmentCommandParserTest.java
@@ -55,7 +55,6 @@ public class EditAssignmentCommandParserTest {
                 new AssignmentQuery(null,
                         new Deadline(VALID_DEADLINE_2024_10_20),
                         new Status(VALID_STATUS_Y),
-                        new Status(VALID_STATUS_Y),
                         new Grade(VALID_GRADE_80)));
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -67,7 +66,7 @@ public class EditAssignmentCommandParserTest {
 
         EditAssignmentCommand expectedCommand = new EditAssignmentCommand(
                 new Name(VALID_NAME_AMY), new AssignmentName(VALID_ASSIGNMENT_MATH),
-                new AssignmentQuery(null, null, null, null, null));
+                new AssignmentQuery(null, null, null, null));
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -81,7 +80,6 @@ public class EditAssignmentCommandParserTest {
                 new Name(VALID_NAME_AMY), new AssignmentName(VALID_ASSIGNMENT_MATH),
                 new AssignmentQuery(null,
                         new Deadline(VALID_DEADLINE_2024_10_20),
-                        new Status(VALID_STATUS_Y),
                         new Status(VALID_STATUS_Y),
                         new Grade(VALID_GRADE_80)),
                 new StudentNumber(VALID_STUDENT_NUMBER_HUGH));

--- a/src/test/java/seedu/address/model/assignment/AssignmentQueryTest.java
+++ b/src/test/java/seedu/address/model/assignment/AssignmentQueryTest.java
@@ -17,45 +17,45 @@ public class AssignmentQueryTest {
 
     @Test
     public void equals_sameAttributes_returnsTrue() {
-        AssignmentQuery queryA = new AssignmentQuery(ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, STATUS_N, GRADE_80);
-        AssignmentQuery queryB = new AssignmentQuery(ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, STATUS_N, GRADE_80);
+        AssignmentQuery queryA = new AssignmentQuery(ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, GRADE_80);
+        AssignmentQuery queryB = new AssignmentQuery(ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, GRADE_80);
         assertTrue(queryA.equals(queryB));
         assertTrue(queryA.equals(queryA));
     }
 
     @Test
     public void equals_differentAttributes_returnsFalse() {
-        AssignmentQuery queryA = new AssignmentQuery(ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, STATUS_N, GRADE_80);
-        AssignmentQuery queryB = new AssignmentQuery(ASSIGNMENT_NAME_B, DEADLINE_B, STATUS_N, STATUS_N, GRADE_90);
+        AssignmentQuery queryA = new AssignmentQuery(ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, GRADE_80);
+        AssignmentQuery queryB = new AssignmentQuery(ASSIGNMENT_NAME_B, DEADLINE_B, STATUS_N, GRADE_90);
         assertFalse(queryA.equals(queryB));
     }
 
     @Test
     public void equals_differentObject_returnsFalse() {
-        AssignmentQuery queryA = new AssignmentQuery(ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, STATUS_N, GRADE_80);
+        AssignmentQuery queryA = new AssignmentQuery(ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, GRADE_80);
         assertFalse(queryA.equals(1));
         assertFalse(queryA.equals("OMEGA"));
     }
 
     @Test
     public void matchQuery_queryWithMatchingAssignment_returnsTrue() {
-        AssignmentQuery query = new AssignmentQuery(ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, STATUS_N, GRADE_80);
-        Assignment matchingAssignment = new Assignment(ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, STATUS_N, GRADE_80);
+        AssignmentQuery query = new AssignmentQuery(ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, GRADE_80);
+        Assignment matchingAssignment = new Assignment(ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, GRADE_80);
         assertTrue(query.match(matchingAssignment));
     }
 
     @Test
     public void matchQuery_queryWithNonMatchingAssignment_returnsFalse() {
-        AssignmentQuery query = new AssignmentQuery(ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, STATUS_N, GRADE_80);
-        Assignment nonMatchingAssignment = new Assignment(ASSIGNMENT_NAME_B, DEADLINE_B, STATUS_N, STATUS_Y, GRADE_90);
+        AssignmentQuery query = new AssignmentQuery(ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, GRADE_80);
+        Assignment nonMatchingAssignment = new Assignment(ASSIGNMENT_NAME_B, DEADLINE_B, STATUS_N, GRADE_90);
         assertFalse(query.match(nonMatchingAssignment));
     }
 
     @Test
     public void matchQuery_queryWithEmptyFields_returnsTrue() {
         // Empty fields should match any corresponding field in assignment
-        AssignmentQuery query = new AssignmentQuery(null, null, null, null, null);
-        Assignment assignment = new Assignment(ASSIGNMENT_NAME_B, DEADLINE_B, STATUS_N, STATUS_Y, GRADE_90);
+        AssignmentQuery query = new AssignmentQuery(null, null, null, null);
+        Assignment assignment = new Assignment(ASSIGNMENT_NAME_B, DEADLINE_B, STATUS_N, GRADE_90);
         assertTrue(query.match(assignment));
     }
 }

--- a/src/test/java/seedu/address/model/assignment/AssignmentTest.java
+++ b/src/test/java/seedu/address/model/assignment/AssignmentTest.java
@@ -22,8 +22,7 @@ public class AssignmentTest {
 
     @BeforeEach
     void setUp() {
-        assignment = new Assignment(ORIGINAL_NAME, ORIGINAL_DEADLINE, ORIGINAL_SUBMISSION_STATUS,
-                ORIGINAL_GRADING_STATUS, ORIGINAL_GRADE);
+        assignment = new Assignment(ORIGINAL_NAME, ORIGINAL_DEADLINE, ORIGINAL_SUBMISSION_STATUS, ORIGINAL_GRADE);
     }
 
     @Test
@@ -31,86 +30,68 @@ public class AssignmentTest {
         String expected = Assignment.class.getCanonicalName() + "{name=" + MATH_ASSIGNMENT_SUBMITTED.getAssignmentName()
                 + ", deadline=" + MATH_ASSIGNMENT_SUBMITTED.getDeadline() + ", submission status="
                 + MATH_ASSIGNMENT_SUBMITTED.getSubmissionStatus()
-                + ", grading status=" + MATH_ASSIGNMENT_SUBMITTED.getGradingStatus()
                 + ", grade=" + MATH_ASSIGNMENT_SUBMITTED.getGrade() + "}";
         assertEquals(expected, MATH_ASSIGNMENT_SUBMITTED.toString());
     }
 
     @Test
     void edit_editDeadline_updatesDeadline() {
-        AssignmentQuery query = new AssignmentQuery(null, NEW_DEADLINE, null, null, null);
+        AssignmentQuery query = new AssignmentQuery(null, NEW_DEADLINE, null, null);
         assignment.edit(query);
 
         assertEquals(NEW_DEADLINE, assignment.getDeadline());
         assertEquals(ORIGINAL_SUBMISSION_STATUS, assignment.getSubmissionStatus());
-        assertEquals(ORIGINAL_GRADING_STATUS, assignment.getGradingStatus());
         assertEquals(ORIGINAL_GRADE, assignment.getGrade());
     }
 
     @Test
     void edit_editSubmissionStatus_updatesSubmissionStatus() {
-        AssignmentQuery query = new AssignmentQuery(null, null, NEW_SUBMISSION_STATUS, null, null);
+        AssignmentQuery query = new AssignmentQuery(null, null, NEW_SUBMISSION_STATUS, null);
         assignment.edit(query);
 
         assertEquals(ORIGINAL_DEADLINE, assignment.getDeadline());
         assertEquals(NEW_SUBMISSION_STATUS, assignment.getSubmissionStatus());
-        assertEquals(ORIGINAL_GRADING_STATUS, assignment.getGradingStatus());
-        assertEquals(ORIGINAL_GRADE, assignment.getGrade());
-    }
-
-    @Test
-    void edit_editGradingStatus_updatesGradingStatus() {
-        AssignmentQuery query = new AssignmentQuery(null, null, null, NEW_GRADING_STATUS, null);
-        assignment.edit(query);
-
-        assertEquals(ORIGINAL_DEADLINE, assignment.getDeadline());
-        assertEquals(ORIGINAL_SUBMISSION_STATUS, assignment.getSubmissionStatus());
-        assertEquals(NEW_GRADING_STATUS, assignment.getGradingStatus());
         assertEquals(ORIGINAL_GRADE, assignment.getGrade());
     }
 
     @Test
     void edit_editGrade_updatesGrade() {
-        AssignmentQuery query = new AssignmentQuery(null, null, null, null, NEW_GRADE);
+        AssignmentQuery query = new AssignmentQuery(null, null, null, NEW_GRADE);
         assignment.edit(query);
 
         assertEquals(ORIGINAL_DEADLINE, assignment.getDeadline());
         assertEquals(ORIGINAL_SUBMISSION_STATUS, assignment.getSubmissionStatus());
-        assertEquals(ORIGINAL_GRADING_STATUS, assignment.getGradingStatus());
         assertEquals(NEW_GRADE, assignment.getGrade());
     }
 
     @Test
     void edit_editMultipleFields_updatesFields() {
-        AssignmentQuery query = new AssignmentQuery(null, NEW_DEADLINE, NEW_SUBMISSION_STATUS,
-                NEW_GRADING_STATUS, NEW_GRADE);
+        AssignmentQuery query = new AssignmentQuery(null, NEW_DEADLINE, NEW_SUBMISSION_STATUS, NEW_GRADE);
         assignment.edit(query);
 
         assertEquals(NEW_DEADLINE, assignment.getDeadline());
         assertEquals(NEW_SUBMISSION_STATUS, assignment.getSubmissionStatus());
-        assertEquals(NEW_GRADING_STATUS, assignment.getGradingStatus());
         assertEquals(NEW_GRADE, assignment.getGrade());
     }
 
     @Test
     void edit_noChanges_originalFieldsRemainUnchanged() {
-        AssignmentQuery query = new AssignmentQuery(null, null, null, null, null);
+        AssignmentQuery query = new AssignmentQuery(null, null, null, null);
         assignment.edit(query);
 
         assertEquals(ORIGINAL_DEADLINE, assignment.getDeadline());
         assertEquals(ORIGINAL_SUBMISSION_STATUS, assignment.getSubmissionStatus());
-        assertEquals(ORIGINAL_GRADING_STATUS, assignment.getGradingStatus());
         assertEquals(ORIGINAL_GRADE, assignment.getGrade());
     }
 
     @Test
     void edit_nullGrade_doesNotChangeGrade() {
-        AssignmentQuery query = new AssignmentQuery(null, null, null, null, null);
+        AssignmentQuery query = new AssignmentQuery(null, null, null, null);
         assignment.edit(query);
         assertEquals(ORIGINAL_GRADE, assignment.getGrade());
 
         // Test with an empty optional
-        AssignmentQuery queryWithEmptyGrade = new AssignmentQuery(null, null, null, null, null);
+        AssignmentQuery queryWithEmptyGrade = new AssignmentQuery(null, null, null, null);
         assignment.edit(queryWithEmptyGrade);
         assertEquals(ORIGINAL_GRADE, assignment.getGrade());
     }

--- a/src/test/java/seedu/address/model/assignment/StatusTest.java
+++ b/src/test/java/seedu/address/model/assignment/StatusTest.java
@@ -60,8 +60,8 @@ public class StatusTest {
         Status graded = new Status("Y");
         Status notGraded = new Status("N");
 
-        assertTrue(graded.isGraded()); // should be true for Y
-        assertFalse(notGraded.isGraded()); // should be false for N
+        assertTrue(graded.isSubmitted()); // should be true for Y
+        assertFalse(notGraded.isSubmitted()); // should be false for N
     }
 
     @Test

--- a/src/test/java/seedu/address/model/student/StudentTest.java
+++ b/src/test/java/seedu/address/model/student/StudentTest.java
@@ -257,7 +257,7 @@ public class StudentTest {
     void editAssignment_nonExistentAssignment_returnsNull() {
         // Attempt to edit an assignment that doesn't exist
         AssignmentName nonExistentName = new AssignmentName("Nonexistent Homework");
-        AssignmentQuery query = new AssignmentQuery(null, DEADLINE_C, STATUS_Y, STATUS_Y, GRADE_90);
+        AssignmentQuery query = new AssignmentQuery(null, DEADLINE_C, STATUS_Y, GRADE_90);
 
         AssignmentQuery result = student.editAssignment(nonExistentName, query);
 
@@ -269,7 +269,7 @@ public class StudentTest {
     void editAssignment_existingAssignment_editsAssignment() {
         // Create AssignmentQuery with new values to edit
         Assignment oldAssignment = new AssignmentBuilder(MATH_ASSIGNMENT_SUBMITTED).build();
-        AssignmentQuery query = new AssignmentQuery(null, DEADLINE_C, STATUS_Y, STATUS_Y, GRADE_90);
+        AssignmentQuery query = new AssignmentQuery(null, DEADLINE_C, STATUS_Y, GRADE_90);
 
         // Perform the edit operation
         AssignmentQuery oldAssignmentQuery = student.editAssignment(ASSIGNMENT_NAME_A, query);
@@ -281,7 +281,6 @@ public class StudentTest {
         Assignment updatedAssignment = student.getAssignments().get(0);
         assertEquals(DEADLINE_C, updatedAssignment.getDeadline());
         assertEquals(STATUS_Y, updatedAssignment.getSubmissionStatus());
-        assertEquals(STATUS_Y, updatedAssignment.getGradingStatus());
         assertEquals(GRADE_90, updatedAssignment.getGrade());
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedAssignmentTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedAssignmentTest.java
@@ -23,7 +23,6 @@ public class JsonAdaptedAssignmentTest {
     private static final String VALID_DEADLINE = MATH_ASSIGNMENT_SUBMITTED.getDeadline().deadline.toString();
     private static final String VALID_SUBMISSION_STATUS = MATH_ASSIGNMENT_SUBMITTED
             .getSubmissionStatus().status.toString();
-    private static final String VALID_GRADING_STATUS = MATH_ASSIGNMENT_SUBMITTED.getGradingStatus().status.toString();
     private static final String VALID_GRADE = MATH_ASSIGNMENT_SUBMITTED.getGrade().grade
             .map(x -> x.toString()).orElse("NULL");
 
@@ -37,7 +36,7 @@ public class JsonAdaptedAssignmentTest {
     public void toModelType_invalidAssignmentName_throwsIllegalValueException() {
         JsonAdaptedAssignment assignment =
                 new JsonAdaptedAssignment(INVALID_ASSIGNMENT_NAME, VALID_DEADLINE, VALID_SUBMISSION_STATUS,
-                        VALID_GRADING_STATUS, VALID_GRADE);
+                        VALID_GRADE);
         String expectedMessage = AssignmentName.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, assignment::toModelType);
     }
@@ -45,8 +44,7 @@ public class JsonAdaptedAssignmentTest {
     @Test
     public void toModelType_nullAssignmentName_throwsIllegalValueException() {
         JsonAdaptedAssignment assignment =
-                new JsonAdaptedAssignment(null, VALID_DEADLINE, VALID_SUBMISSION_STATUS,
-                        VALID_GRADING_STATUS, VALID_GRADE);
+                new JsonAdaptedAssignment(null, VALID_DEADLINE, VALID_SUBMISSION_STATUS, VALID_GRADE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, AssignmentName.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, assignment::toModelType);
     }
@@ -55,7 +53,7 @@ public class JsonAdaptedAssignmentTest {
     public void toModelType_invalidDeadline_throwsIllegalValueException() {
         JsonAdaptedAssignment assignment =
                 new JsonAdaptedAssignment(VALID_ASSIGNMENT_NAME, INVALID_DEADLINE, VALID_SUBMISSION_STATUS,
-                        VALID_GRADING_STATUS, VALID_GRADE);
+                        VALID_GRADE);
         String expectedMessage = Deadline.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, assignment::toModelType);
     }
@@ -63,8 +61,7 @@ public class JsonAdaptedAssignmentTest {
     @Test
     public void toModelType_nullDeadline_throwsIllegalValueException() {
         JsonAdaptedAssignment assignment =
-                new JsonAdaptedAssignment(VALID_ASSIGNMENT_NAME, null, VALID_SUBMISSION_STATUS,
-                        VALID_GRADING_STATUS, VALID_GRADE);
+                new JsonAdaptedAssignment(VALID_ASSIGNMENT_NAME, null, VALID_SUBMISSION_STATUS, VALID_GRADE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Deadline.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, assignment::toModelType);
     }
@@ -72,8 +69,7 @@ public class JsonAdaptedAssignmentTest {
     @Test
     public void toModelType_invalidSubmissionStatus_throwsIllegalValueException() {
         JsonAdaptedAssignment assignment =
-                new JsonAdaptedAssignment(VALID_ASSIGNMENT_NAME, VALID_DEADLINE, INVALID_STATUS,
-                        VALID_GRADING_STATUS, VALID_GRADE);
+                new JsonAdaptedAssignment(VALID_ASSIGNMENT_NAME, VALID_DEADLINE, INVALID_STATUS, VALID_GRADE);
         String expectedMessage = Status.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, assignment::toModelType);
     }
@@ -81,8 +77,7 @@ public class JsonAdaptedAssignmentTest {
     @Test
     public void toModelType_nullSubmissionStatus_throwsIllegalValueException() {
         JsonAdaptedAssignment assignment =
-                new JsonAdaptedAssignment(VALID_ASSIGNMENT_NAME, VALID_DEADLINE, null,
-                        VALID_GRADING_STATUS, VALID_GRADE);
+                new JsonAdaptedAssignment(VALID_ASSIGNMENT_NAME, VALID_DEADLINE, null, VALID_GRADE);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Status.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, assignment::toModelType);
     }
@@ -91,7 +86,7 @@ public class JsonAdaptedAssignmentTest {
     public void toModelType_invalidGrade_throwsIllegalValueException() {
         JsonAdaptedAssignment assignment =
                 new JsonAdaptedAssignment(VALID_ASSIGNMENT_NAME, VALID_DEADLINE, VALID_SUBMISSION_STATUS,
-                        VALID_GRADING_STATUS, INVALID_GRADE);
+                        INVALID_GRADE);
         String expectedMessage = Grade.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, assignment::toModelType);
     }
@@ -99,8 +94,7 @@ public class JsonAdaptedAssignmentTest {
     @Test
     public void toModelType_nullGrade_throwsIllegalValueException() {
         JsonAdaptedAssignment assignment =
-                new JsonAdaptedAssignment(VALID_ASSIGNMENT_NAME, VALID_DEADLINE, VALID_SUBMISSION_STATUS,
-                        VALID_GRADING_STATUS, null);
+                new JsonAdaptedAssignment(VALID_ASSIGNMENT_NAME, VALID_DEADLINE, VALID_SUBMISSION_STATUS, null);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Grade.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, assignment::toModelType);
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedStudentTest.java
@@ -123,7 +123,7 @@ public class JsonAdaptedStudentTest {
     @Test
     public void toModelType_invalidAssignment_throwsIllegalValueException() {
         List<JsonAdaptedAssignment> invalidAssignments = List.of(new JsonAdaptedAssignment(
-                null, "2024-10-22", "submitted", "graded", "A"));
+                null, "2024-10-22", "submitted", "A"));
         JsonAdaptedStudent student =
                 new JsonAdaptedStudent(VALID_NAME, VALID_PHONE, VALID_TUTORIAL_GROUP,
                         VALID_STUDENT_NUMBER, invalidAssignments, VALID_ATTENDANCE_RECORD);

--- a/src/test/java/seedu/address/testutil/AssignmentBuilder.java
+++ b/src/test/java/seedu/address/testutil/AssignmentBuilder.java
@@ -16,7 +16,6 @@ public class AssignmentBuilder {
     private AssignmentName name;
     private Deadline deadline;
     private Status submissionStatus;
-    private Status gradingStatus;
     private Grade grade;
 
     /**
@@ -26,7 +25,6 @@ public class AssignmentBuilder {
         this.name = new AssignmentName(DEFAULT_NAME);
         this.deadline = new Deadline(DEFAULT_DEADLINE);
         this.submissionStatus = Status.getDefault();
-        this.gradingStatus = Status.getDefault();
         this.grade = Grade.getDefault();
     }
 
@@ -37,7 +35,6 @@ public class AssignmentBuilder {
         this.name = assignment.getAssignmentName();
         this.deadline = assignment.getDeadline();
         this.submissionStatus = assignment.getSubmissionStatus();
-        this.gradingStatus = assignment.getGradingStatus();
         this.grade = assignment.getGrade();
     }
 
@@ -75,17 +72,6 @@ public class AssignmentBuilder {
     }
 
     /**
-     * Sets the {@code Grading Status} of the {@code Assignment} that we are building.
-     *
-     * @param gradingStatus The grading status to set.
-     * @return The updated {@code AssignmentBuilder} object.
-     */
-    public AssignmentBuilder withGradingStatus(String gradingStatus) {
-        this.gradingStatus = new Status(gradingStatus);
-        return this;
-    }
-
-    /**
      * Sets the {@code Grade} of the {@code Assignment} that we are building.
      *
      * @param grade The grade to set.
@@ -97,7 +83,7 @@ public class AssignmentBuilder {
     }
 
     public Assignment build() {
-        return new Assignment(name, deadline, submissionStatus, gradingStatus, grade);
+        return new Assignment(name, deadline, submissionStatus, grade);
     }
 
 

--- a/src/test/java/seedu/address/testutil/StudentBuilder.java
+++ b/src/test/java/seedu/address/testutil/StudentBuilder.java
@@ -39,7 +39,6 @@ public class StudentBuilder {
             new AssignmentName(DEFAULT_ASSIGNMENT_NAME),
             new Deadline(DEFAULT_DEADLINE),
             new Status(DEFAULT_SUBMISSION_STATUS),
-            new Status(DEFAULT_GRADING_STATUS),
             new Grade(DEFAULT_GRADE)
     );
 
@@ -122,12 +121,11 @@ public class StudentBuilder {
      * Sets the {@code Assignment} of the {@code StudentTest} that we are building.
      */
     public StudentBuilder withAssignment(String assignmentName, String deadline, String submissionStatus,
-                                         String gradingStatus, String grade) {
+                                         String grade) {
         Assignment assignment = new Assignment(
                 new AssignmentName(assignmentName),
                 new Deadline(deadline),
                 new Status(submissionStatus),
-                new Status(gradingStatus),
                 new Grade(grade)
         );
         assignments.add(assignment);

--- a/src/test/java/seedu/address/testutil/TypicalAssignments.java
+++ b/src/test/java/seedu/address/testutil/TypicalAssignments.java
@@ -29,15 +29,15 @@ public class TypicalAssignments {
 
     // Typical Assignments for testing
     public static final Assignment MATH_ASSIGNMENT_SUBMITTED = new Assignment(
-            ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, STATUS_N, GRADE_NULL
+            ASSIGNMENT_NAME_A, DEADLINE_A, STATUS_Y, GRADE_NULL
     );
 
     public static final Assignment SCIENCE_ASSIGNMENT_GRADED = new Assignment(
-            ASSIGNMENT_NAME_B, DEADLINE_B, STATUS_Y, STATUS_Y, GRADE_90
+            ASSIGNMENT_NAME_B, DEADLINE_B, STATUS_Y, GRADE_90
     );
 
     public static final Assignment ENGLISH_ASSIGNMENT_NOT_SUBMITTED = new Assignment(
-            ASSIGNMENT_NAME_C, DEADLINE_C, STATUS_N, STATUS_N, GRADE_NULL
+            ASSIGNMENT_NAME_C, DEADLINE_C, STATUS_N, GRADE_NULL
     );
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalStudents.java
+++ b/src/test/java/seedu/address/testutil/TypicalStudents.java
@@ -39,7 +39,7 @@ public class TypicalStudents {
             .withPhone("81234567").withTutorialGroup("B11")
             .withStudentNumber("A0123456M")
             .withAssignment("Assignment 1", "2021-10-10",
-                    "Y", "Y", "95").build();
+                    "Y", "95").build();
 
     static {
         //Adding attendance records for ALICE
@@ -52,37 +52,37 @@ public class TypicalStudents {
             .withPhone("91234567").withTutorialGroup("C21")
             .withStudentNumber("A0654321X")
             .withAssignment("Assignment 2", "2021-10-11",
-                    "N", "N", "10").build();
+                    "N", "10").build();
 
     public static final Student CHARLIE = new StudentBuilder().withName("Charlie Lim")
             .withPhone("83312233").withTutorialGroup("A10")
             .withStudentNumber("A0987654Z")
             .withAssignment("Assignment 3", "2021-10-12",
-                    "Y", "N", "20").build();
+                    "Y", "20").build();
 
     public static final Student DAVID = new StudentBuilder().withName("David Lee")
             .withPhone("89994444").withTutorialGroup("D14")
             .withStudentNumber("A0345678K")
             .withAssignment("Assignment 4", "2021-10-13",
-                    "N", "Y", "30").build();
+                    "N", "30").build();
 
     public static final Student ELLA = new StudentBuilder().withName("Ella Wong")
             .withPhone("84443322").withTutorialGroup("E31")
             .withStudentNumber("A0543217J")
             .withAssignment("Assignment 5", "2021-10-14",
-                    "Y", "Y", "40").build();
+                    "Y", "40").build();
 
     public static final Student FRANK = new StudentBuilder().withName("Frank Ho")
             .withPhone("88881111").withTutorialGroup("F12")
             .withStudentNumber("A0135792H")
             .withAssignment("Assignment 6", "2021-10-15",
-                    "N", "N", "50").build();
+                    "N", "50").build();
 
     public static final Student GRACE = new StudentBuilder().withName("Grace Ng")
             .withPhone("81119988").withTutorialGroup("G23")
             .withStudentNumber("A0988765T")
             .withAssignment("Assignment 7", "2021-10-16",
-                    "Y", "N", "60").build();
+                    "Y", "60").build();
 
 
     private TypicalStudents() {} // prevents instantiation


### PR DESCRIPTION
Grading status and grade were both stored in assignment.

This is redundant since an empty grade implies assignment has not been graded. Let's change it so that we only store a grade. This reduces the need for unnecessary checking.

Submission status and grade are reworked to ensure validity as well.

Closes #188 
Closes #189 
Closes #190